### PR TITLE
Added support to split large sets of logstreams into multiple requests.

### DIFF
--- a/go-cloudwatch.go
+++ b/go-cloudwatch.go
@@ -1,6 +1,10 @@
 package cloudwatchlogs
 
 import (
+	"math"
+	"strings"
+	"sync"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 )
@@ -91,30 +95,70 @@ func getStreams(client *cloudwatchlogs.CloudWatchLogs, group, prefix string, sta
 	}
 }
 
+type safeEvents struct {
+	events []*cloudwatchlogs.FilteredLogEvent
+	mux    sync.Mutex
+}
+
+// Append adds events to the store.
+func(s *safeEvents) Append(events []*cloudwatchlogs.FilteredLogEvent) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	for _, v := range events {
+		s.events = append(s.events, v)
+	}
+}
+
+// Get returns the events.
+func(s *safeEvents) Get() []*cloudwatchlogs.FilteredLogEvent {
+	return s.events
+}
+
 // Helper function to get logs.
 func getLogs(client *cloudwatchlogs.CloudWatchLogs, group string, streams []*string, start, end int64) ([]*cloudwatchlogs.FilteredLogEvent, error) {
-	var events []*cloudwatchlogs.FilteredLogEvent
+	// Cloudwatch has a maximum of 100 logstreams per api request.
+	var wg sync.WaitGroup
+	requestPools := int(math.Ceil(float64(len(streams)) / 100))
+	wg.Add(requestPools)
 
-	params := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName:   aws.String(group),
-		LogStreamNames: streams,
-		StartTime:      &start,
-		EndTime:        &end,
-		Interleaved:    aws.Bool(true),
+	events := safeEvents{}
+	for i := 0; i < requestPools; i++ {
+		min := i
+		max := i + 100
+		var poolStreams = []*string{}
+		for ii := min; ii < max; ii++ {
+			if len(streams) <= ii { break }
+			poolStreams = append(poolStreams, streams[ii])
+		}
+		go func(streams []*string) {
+			defer wg.Done()
+
+			params := &cloudwatchlogs.FilterLogEventsInput{
+				LogGroupName:   aws.String(group),
+				LogStreamNames: streams,
+				StartTime:      &start,
+				EndTime:        &end,
+				Interleaved:    aws.Bool(true),
+			}
+
+			for {
+				resp, err := client.FilterLogEvents(params)
+				if err != nil {
+					return
+				}
+
+				events.Append(resp.Events)
+
+				if resp.NextToken == nil {
+					return
+				}
+
+				params.NextToken = resp.NextToken
+			}
+		}(poolStreams)
 	}
 
-	for {
-		resp, err := client.FilterLogEvents(params)
-		if err != nil {
-			return events, err
-		}
-
-		events = append(events, resp.Events...)
-
-		if resp.NextToken == nil {
-			return events, nil
-		}
-
-		params.NextToken = resp.NextToken
-	}
+	wg.Wait()
+	return events.Get(), nil
 }


### PR DESCRIPTION
#### What does this PR do?

The Cloudwatch api has a maximum of 100 logstreams per query. This change splits up logstreams into pools of <=100.

